### PR TITLE
Updating it to use React v15.6

### DIFF
--- a/lib/Circle.js
+++ b/lib/Circle.js
@@ -4,11 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _internalsSimpleChildComponent = require("./internals/SimpleChildComponent");
 
@@ -19,15 +21,13 @@ var _internalsCreateRegisterEvents = require("./internals/createRegisterEvents")
 var _internalsCreateRegisterEvents2 = _interopRequireDefault(_internalsCreateRegisterEvents);
 
 var Circle = (function (_SimpleChildComponent) {
+  _inherits(Circle, _SimpleChildComponent);
+
   function Circle() {
     _classCallCheck(this, Circle);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(Circle.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(Circle, _SimpleChildComponent);
 
   return Circle;
 })(_internalsSimpleChildComponent2["default"]);

--- a/lib/DirectionsRenderer.js
+++ b/lib/DirectionsRenderer.js
@@ -4,11 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _internalsSimpleChildComponent = require("./internals/SimpleChildComponent");
 
@@ -23,15 +25,13 @@ var _internalsBASIC_EVENT_NAMES = require("./internals/BASIC_EVENT_NAMES");
 var _internalsBASIC_EVENT_NAMES2 = _interopRequireDefault(_internalsBASIC_EVENT_NAMES);
 
 var DirectionsRenderer = (function (_SimpleChildComponent) {
+  _inherits(DirectionsRenderer, _SimpleChildComponent);
+
   function DirectionsRenderer() {
     _classCallCheck(this, DirectionsRenderer);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(DirectionsRenderer.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(DirectionsRenderer, _SimpleChildComponent);
 
   return DirectionsRenderer;
 })(_internalsSimpleChildComponent2["default"]);

--- a/lib/DrawingManager.js
+++ b/lib/DrawingManager.js
@@ -4,11 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _internalsSimpleChildComponent = require("./internals/SimpleChildComponent");
 
@@ -19,15 +21,13 @@ var _internalsCreateRegisterEvents = require("./internals/createRegisterEvents")
 var _internalsCreateRegisterEvents2 = _interopRequireDefault(_internalsCreateRegisterEvents);
 
 var DrawingManager = (function (_SimpleChildComponent) {
+  _inherits(DrawingManager, _SimpleChildComponent);
+
   function DrawingManager() {
     _classCallCheck(this, DrawingManager);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(DrawingManager.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(DrawingManager, _SimpleChildComponent);
 
   return DrawingManager;
 })(_internalsSimpleChildComponent2["default"]);

--- a/lib/GoogleMaps.js
+++ b/lib/GoogleMaps.js
@@ -8,7 +8,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -16,11 +16,19 @@ function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in ob
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require("react-dom");
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _internalsEventComponent = require("./internals/EventComponent");
 
@@ -42,24 +50,7 @@ var _internalsCreateRegisterEvents = require("./internals/createRegisterEvents")
 
 var _internalsCreateRegisterEvents2 = _interopRequireDefault(_internalsCreateRegisterEvents);
 
-var PropTypes = _react2["default"].PropTypes;
-
 var GoogleMaps = (function (_EventComponent) {
-  /*
-   * Internals
-   */
-
-  function GoogleMaps() {
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
-
-    _classCallCheck(this, GoogleMaps);
-
-    _get(Object.getPrototypeOf(GoogleMaps.prototype), "constructor", this).apply(this, args);
-    this.state = {};
-  }
-
   _inherits(GoogleMaps, _EventComponent);
 
   _createClass(GoogleMaps, [{
@@ -102,7 +93,24 @@ var GoogleMaps = (function (_EventComponent) {
         instance.fitBounds(latLngBounds);
       }
     }
-  }, {
+
+    /*
+     * Internals
+     */
+  }]);
+
+  function GoogleMaps() {
+    _classCallCheck(this, GoogleMaps);
+
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    _get(Object.getPrototypeOf(GoogleMaps.prototype), "constructor", this).apply(this, args);
+    this.state = {};
+  }
+
+  _createClass(GoogleMaps, [{
     key: "_createOrUpdateInstance",
     value: function _createOrUpdateInstance() {
       var props = this.props;
@@ -124,7 +132,7 @@ var GoogleMaps = (function (_EventComponent) {
         instance.setOptions(googleMapsConfig);
       } else {
         var GoogleMapsClass = googleMapsApi.Map;
-        instance = new GoogleMapsClass(_react2["default"].findDOMNode(this.refs.googleMaps), googleMapsConfig);
+        instance = new GoogleMapsClass(_reactDom2["default"].findDOMNode(this.refs.googleMaps), googleMapsConfig);
         (0, _internalsExposeGetters2["default"])(this, GoogleMapsClass.prototype, instance);
 
         this.setState({ instance: instance });
@@ -167,7 +175,7 @@ var GoogleMaps = (function (_EventComponent) {
 })(_internalsEventComponent2["default"]);
 
 GoogleMaps.propTypes = _extends({}, _internalsEventComponent2["default"].propTypes, {
-  containerProps: PropTypes.object.isRequired
+  containerProps: _propTypes2["default"].object.isRequired
 });
 
 GoogleMaps._registerEvents = (0, _internalsCreateRegisterEvents2["default"])("bounds_changed center_changed click dblclick drag dragend dragstart heading_changed idle maptypeid_changed mousemove mouseout mouseover projection_changed resize rightclick tilesloaded tilt_changed zoom_changed");

--- a/lib/InfoWindow.js
+++ b/lib/InfoWindow.js
@@ -8,17 +8,21 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _internalsSimpleChildComponent = require("./internals/SimpleChildComponent");
 
@@ -28,18 +32,14 @@ var _internalsCreateRegisterEvents = require("./internals/createRegisterEvents")
 
 var _internalsCreateRegisterEvents2 = _interopRequireDefault(_internalsCreateRegisterEvents);
 
-var PropTypes = _react2["default"].PropTypes;
-
 var InfoWindow = (function (_SimpleChildComponent) {
+  _inherits(InfoWindow, _SimpleChildComponent);
+
   function InfoWindow() {
     _classCallCheck(this, InfoWindow);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(InfoWindow.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(InfoWindow, _SimpleChildComponent);
 
   _createClass(InfoWindow, [{
     key: "_createOrUpdateInstance",
@@ -56,7 +56,7 @@ var InfoWindow = (function (_SimpleChildComponent) {
 })(_internalsSimpleChildComponent2["default"]);
 
 InfoWindow.propTypes = _extends({}, _internalsSimpleChildComponent2["default"].propTypes, {
-  anchor: PropTypes.object
+  anchor: _propTypes2["default"].object
 });
 
 InfoWindow._GoogleMapsClassName = "InfoWindow";

--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -6,11 +6,13 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require("react");
 
@@ -31,15 +33,13 @@ var _InfoWindow2 = _interopRequireDefault(_InfoWindow);
 var Children = _react2["default"].Children;
 
 var Marker = (function (_SimpleChildComponent) {
+  _inherits(Marker, _SimpleChildComponent);
+
   function Marker() {
     _classCallCheck(this, Marker);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(Marker.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(Marker, _SimpleChildComponent);
 
   _createClass(Marker, [{
     key: "render",

--- a/lib/Polygon.js
+++ b/lib/Polygon.js
@@ -4,11 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _internalsSimpleChildComponent = require("./internals/SimpleChildComponent");
 
@@ -23,15 +25,13 @@ var _internalsBASIC_EVENT_NAMES = require("./internals/BASIC_EVENT_NAMES");
 var _internalsBASIC_EVENT_NAMES2 = _interopRequireDefault(_internalsBASIC_EVENT_NAMES);
 
 var Polygon = (function (_SimpleChildComponent) {
+  _inherits(Polygon, _SimpleChildComponent);
+
   function Polygon() {
     _classCallCheck(this, Polygon);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(Polygon.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(Polygon, _SimpleChildComponent);
 
   return Polygon;
 })(_internalsSimpleChildComponent2["default"]);

--- a/lib/Polyline.js
+++ b/lib/Polyline.js
@@ -4,11 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _internalsSimpleChildComponent = require("./internals/SimpleChildComponent");
 
@@ -23,15 +25,13 @@ var _internalsBASIC_EVENT_NAMES = require("./internals/BASIC_EVENT_NAMES");
 var _internalsBASIC_EVENT_NAMES2 = _interopRequireDefault(_internalsBASIC_EVENT_NAMES);
 
 var Polyline = (function (_SimpleChildComponent) {
+  _inherits(Polyline, _SimpleChildComponent);
+
   function Polyline() {
     _classCallCheck(this, Polyline);
 
-    if (_SimpleChildComponent != null) {
-      _SimpleChildComponent.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(Polyline.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(Polyline, _SimpleChildComponent);
 
   return Polyline;
 })(_internalsSimpleChildComponent2["default"]);

--- a/lib/addons/InfoBox.js
+++ b/lib/addons/InfoBox.js
@@ -8,7 +8,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -16,11 +16,11 @@ function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in ob
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var _react = require("react");
+var _propTypes = require("prop-types");
 
-var _react2 = _interopRequireDefault(_react);
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _internalsSimpleChildComponent = require("../internals/SimpleChildComponent");
 
@@ -34,21 +34,19 @@ var _internalsExposeGetters = require("../internals/exposeGetters");
 
 var _internalsExposeGetters2 = _interopRequireDefault(_internalsExposeGetters);
 
-var PropTypes = _react2["default"].PropTypes;
-
 var InfoBox = (function (_SimpleChildComponent) {
+  _inherits(InfoBox, _SimpleChildComponent);
+
   function InfoBox() {
+    _classCallCheck(this, InfoBox);
+
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    _classCallCheck(this, InfoBox);
-
     _get(Object.getPrototypeOf(InfoBox.prototype), "constructor", this).apply(this, args);
     this.state = {};
   }
-
-  _inherits(InfoBox, _SimpleChildComponent);
 
   _createClass(InfoBox, [{
     key: "_createOrUpdateInstance",
@@ -84,7 +82,7 @@ var InfoBox = (function (_SimpleChildComponent) {
 })(_internalsSimpleChildComponent2["default"]);
 
 InfoBox.propTypes = _extends({}, _internalsSimpleChildComponent2["default"].propTypes, {
-  anchor: PropTypes.object
+  anchor: _propTypes2["default"].object
 });
 
 InfoBox._GoogleMapsClassName = "InfoBox";

--- a/lib/internals/EventComponent.js
+++ b/lib/internals/EventComponent.js
@@ -6,23 +6,27 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var PropTypes = _react2["default"].PropTypes;
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function noop() {}
 
 var EventComponent = (function (_React$Component) {
+  _inherits(EventComponent, _React$Component);
+
   /* Contract
    *  statics:
    *    _registerEvents:
@@ -31,18 +35,16 @@ var EventComponent = (function (_React$Component) {
    */
 
   function EventComponent() {
+    _classCallCheck(this, EventComponent);
+
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _classCallCheck(this, EventComponent);
 
     _get(Object.getPrototypeOf(EventComponent.prototype), "constructor", this).apply(this, args);
 
     this._unregisterEvents = noop;
   }
-
-  _inherits(EventComponent, _React$Component);
 
   _createClass(EventComponent, [{
     key: "componentDidMount",
@@ -87,7 +89,7 @@ var EventComponent = (function (_React$Component) {
 })(_react2["default"].Component);
 
 EventComponent.propTypes = {
-  googleMapsApi: PropTypes.object
+  googleMapsApi: _propTypes2["default"].object
 };
 
 exports["default"] = EventComponent;

--- a/lib/internals/SimpleChildComponent.js
+++ b/lib/internals/SimpleChildComponent.js
@@ -8,7 +8,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -16,19 +16,23 @@ function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in ob
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactLibWarning = require("react/lib/warning");
+var _reactDom = require("react-dom");
 
-var _reactLibWarning2 = _interopRequireDefault(_reactLibWarning);
+var _reactDom2 = _interopRequireDefault(_reactDom);
 
 var _objectPath = require("object-path");
 
 var _objectPath2 = _interopRequireDefault(_objectPath);
+
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _EventComponent2 = require("./EventComponent");
 
@@ -38,9 +42,9 @@ var _exposeGetters = require("./exposeGetters");
 
 var _exposeGetters2 = _interopRequireDefault(_exposeGetters);
 
-var PropTypes = _react2["default"].PropTypes;
-
 var SimpleChildComponent = (function (_EventComponent) {
+  _inherits(SimpleChildComponent, _EventComponent);
+
   /* Contract
    *  statics:
    *    _GoogleMapsClassName:
@@ -49,17 +53,15 @@ var SimpleChildComponent = (function (_EventComponent) {
    */
 
   function SimpleChildComponent() {
+    _classCallCheck(this, SimpleChildComponent);
+
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    _classCallCheck(this, SimpleChildComponent);
-
     _get(Object.getPrototypeOf(SimpleChildComponent.prototype), "constructor", this).apply(this, args);
     this.state = {};
   }
-
-  _inherits(SimpleChildComponent, _EventComponent);
 
   _createClass(SimpleChildComponent, [{
     key: "_createOrUpdateInstance",
@@ -85,7 +87,8 @@ var SimpleChildComponent = (function (_EventComponent) {
       } else {
         var googleMapsClassName = this.constructor._GoogleMapsClassName;
         if (!_objectPath2["default"].has(googleMapsApi, googleMapsClassName)) {
-          (0, _reactLibWarning2["default"])(false, "This react-google-maps component can't find the corresponding " + "Google Maps API class 'google.maps.%s'. You may have to include " + "additional Google Maps libraries in your javascript src URL. " + "See: https://developers.google.com/maps/documentation/javascript/libraries", googleMapsClassName);
+          var msg = "This react-google-maps component can't find the corresponding " + "Google Maps API class 'google.maps." + googleMapsClassName + "'. You may have to include " + "additional Google Maps libraries in your javascript src URL. " + "See: https://developers.google.com/maps/documentation/javascript/libraries";
+          console.warn(msg);
           return;
         }
         var GoogleMapsClass = _objectPath2["default"].get(googleMapsApi, googleMapsClassName);
@@ -100,7 +103,7 @@ var SimpleChildComponent = (function (_EventComponent) {
     key: "_handleMissingContent",
     value: function _handleMissingContent(config) {
       var googleMapsClassName = this.constructor._GoogleMapsClassName;
-      if (googleMapsClassName != "InfoWindow" && googleMapsClassName != "InfoBox" || config.content) {
+      if ("InfoWindow" !== googleMapsClassName && "InfoBox" !== googleMapsClassName || config.content) {
         return config;
       } else {
         var detachedDiv = document.createElement("div"),
@@ -108,7 +111,7 @@ var SimpleChildComponent = (function (_EventComponent) {
         if (childComponent.props.wrapperClassName) {
           detachedDiv.className = childComponent.props.wrapperClassName;
         }
-        _react2["default"].render(childComponent, detachedDiv);
+        _reactDom2["default"].render(childComponent, detachedDiv);
         config.content = detachedDiv;
         return config;
       }
@@ -134,7 +137,7 @@ var SimpleChildComponent = (function (_EventComponent) {
 })(_EventComponent3["default"]);
 
 SimpleChildComponent.propTypes = _extends({}, _EventComponent3["default"].propTypes, {
-  map: PropTypes.object
+  map: _propTypes2["default"].object
 });
 
 exports["default"] = SimpleChildComponent;

--- a/lib/internals/VirtualContainer.js
+++ b/lib/internals/VirtualContainer.js
@@ -6,28 +6,30 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var PropTypes = _react2["default"].PropTypes;
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var VirtualContainer = (function (_React$Component) {
+  _inherits(VirtualContainer, _React$Component);
+
   function VirtualContainer() {
     _classCallCheck(this, VirtualContainer);
 
-    if (_React$Component != null) {
-      _React$Component.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(VirtualContainer.prototype), "constructor", this).apply(this, arguments);
   }
-
-  _inherits(VirtualContainer, _React$Component);
 
   _createClass(VirtualContainer, [{
     key: "render",
@@ -61,10 +63,10 @@ var VirtualContainer = (function (_React$Component) {
 })(_react2["default"].Component);
 
 VirtualContainer.propTypes = {
-  googleMapsApi: PropTypes.object.isRequired,
-  map: PropTypes.object.isRequired,
-  children: PropTypes.renderable || PropTypes.node };
+  googleMapsApi: _propTypes2["default"].object.isRequired,
+  map: _propTypes2["default"].object.isRequired,
+  children: _propTypes2["default"].renderable || _propTypes2["default"].node };
 
+// https://github.com/facebook/react/issues/1752#issuecomment-47818166
 exports["default"] = VirtualContainer;
 module.exports = exports["default"];
-// https://github.com/facebook/react/issues/1752#issuecomment-47818166

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "__template__gist__": "https://gist.github.com/tomchentw/368a93bb748ad9d576f1#file-package-json",
   "name": "react-google-maps",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "React.js Google Maps integration component",
   "main": "lib/index.js",
   "files": [
@@ -63,11 +63,15 @@
   },
   "dependencies": {
     "google-maps-infobox": "^1.1.13",
-    "object-path": "^0.9.2",
-    "react": "^0.13.0"
+    "object-path": "^0.11.4",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "^0.13.0"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "prop-types": "^15.5.10"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",

--- a/src/GoogleMaps.js
+++ b/src/GoogleMaps.js
@@ -1,4 +1,6 @@
 import React from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 
 import EventComponent from "./internals/EventComponent";
 /*eslint-disable no-unused-vars */
@@ -6,8 +8,6 @@ import VirtualContainer from "./internals/VirtualContainer";
 /*eslint-enable no-unused-vars */
 import exposeGetters from "./internals/exposeGetters";
 import createRegisterEvents from "./internals/createRegisterEvents";
-
-const {PropTypes} = React;
 
 class GoogleMaps extends EventComponent {
   /*
@@ -64,7 +64,7 @@ class GoogleMaps extends EventComponent {
     } else {
       const GoogleMapsClass = googleMapsApi.Map;
       instance = new GoogleMapsClass(
-        React.findDOMNode(this.refs.googleMaps),
+        ReactDOM.findDOMNode(this.refs.googleMaps),
         googleMapsConfig
       );
       exposeGetters(this, GoogleMapsClass.prototype, instance);

--- a/src/InfoWindow.js
+++ b/src/InfoWindow.js
@@ -1,9 +1,8 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import SimpleChildComponent from "./internals/SimpleChildComponent";
 import createRegisterEvents from "./internals/createRegisterEvents";
-
-const {PropTypes} = React;
 
 class InfoWindow extends SimpleChildComponent {
 

--- a/src/addons/InfoBox.js
+++ b/src/addons/InfoBox.js
@@ -1,9 +1,7 @@
-import React from "react";
+import PropTypes from "prop-types";
 import SimpleChildComponent from "../internals/SimpleChildComponent";
 import createRegisterEvents from "../internals/createRegisterEvents";
 import exposeGetters from "../internals/exposeGetters";
-
-const {PropTypes} = React;
 
 class InfoBox extends SimpleChildComponent {
   constructor (...args) {

--- a/src/internals/EventComponent.js
+++ b/src/internals/EventComponent.js
@@ -1,6 +1,5 @@
 import React from "react";
-
-const {PropTypes} = React;
+import PropTypes from "prop-types";
 
 function noop () {
 }

--- a/src/internals/SimpleChildComponent.js
+++ b/src/internals/SimpleChildComponent.js
@@ -1,11 +1,10 @@
 import React from "react";
-import warning from "react/lib/warning";
+import ReactDOM from "react-dom";
 import objectPath from "object-path";
+import PropTypes from "prop-types";
 
 import EventComponent from "./EventComponent";
 import exposeGetters from "./exposeGetters";
-
-const {PropTypes} = React;
 
 class SimpleChildComponent extends EventComponent {
   /* Contract
@@ -36,12 +35,11 @@ class SimpleChildComponent extends EventComponent {
     } else {
       const googleMapsClassName = this.constructor._GoogleMapsClassName;
       if (!objectPath.has(googleMapsApi, googleMapsClassName)) {
-        warning(false,
-"This react-google-maps component can't find the corresponding " +
-"Google Maps API class 'google.maps.%s'. You may have to include " +
-"additional Google Maps libraries in your javascript src URL. " +
-"See: https://developers.google.com/maps/documentation/javascript/libraries",
-        googleMapsClassName);
+        const msg = "This react-google-maps component can't find the corresponding " +
+        "Google Maps API class 'google.maps." + googleMapsClassName + "'. You may have to include " +
+        "additional Google Maps libraries in your javascript src URL. " +
+        "See: https://developers.google.com/maps/documentation/javascript/libraries";
+        console.warn(msg);
         return;
       }
       const GoogleMapsClass = objectPath.get(googleMapsApi, googleMapsClassName);
@@ -63,7 +61,7 @@ class SimpleChildComponent extends EventComponent {
       if (childComponent.props.wrapperClassName) {
           detachedDiv.className = childComponent.props.wrapperClassName;
       }
-      React.render(childComponent, detachedDiv);
+      ReactDOM.render(childComponent, detachedDiv);
       config.content = detachedDiv;
       return config;
     }

--- a/src/internals/VirtualContainer.js
+++ b/src/internals/VirtualContainer.js
@@ -1,6 +1,5 @@
 import React from "react";
-
-const {PropTypes} = React;
+import PropTypes from "prop-types";
 
 class VirtualContainer extends React.Component {
 


### PR DESCRIPTION
@thetiby - This modifications are needed in order to get our version of `react-google-maps` working with the new version of React. I didn't update the lint packages because it was out of the scope of the updating react ticket, and since when we will update the mapview app at some point I think we also should consider to update or even change the `react-google-maps` package by `google-maps-react` package since it seems better and it also support server side rendering.